### PR TITLE
updated binskim.yml to use tool binskim with MicrosoftSecurityDevOps

### DIFF
--- a/miscellaneous/build_templates/binskim.yml
+++ b/miscellaneous/build_templates/binskim.yml
@@ -1,24 +1,35 @@
+# This template will perform a BinSkim with MicrosoftSecurityDevOps.
 parameters:
-  deleteBinSkim: '' # This parameter is used to delete files before running BinSkim. Only use this if the error has been investigated and can be safely ignored
+- name: binskimPath
+  type: string
+  default: ""
 
 steps:
-  # BinSkim errors if it encounters badly signed Microsoft files
-  # To avoid this issue, delete the files before running BinSkim
-  - task: DeleteFiles@1
-    displayName: 'BinSkim: Delete Files'
-    inputs:
-      SourceFolder: $(Build.SourcesDirectory)
-      Contents: '${{ parameters.deleteBinSkim }}'
-    condition: ne('${{ parameters.deleteBinSkim }}', '')
+# Create binskim folder
+- powershell: |
+    New-Item -ItemType Directory -Force -Path "$(Build.SourcesDirectory)\binskim"
+  displayName: Create folder
 
-  - task: BinSkim@3
-    displayName: 'BinSkim: Analyze'
-    inputs:
-      toolVersion: '1.6.1'
-      AnalyzeTarget: '$(Build.SourcesDirectory)\*.dll;$(Build.SourcesDirectory)\*.exe'
+# Copy files to-be-scanned from Build.SourcesDirectory folder into binskim folder
+- task: CopyFiles@2
+  displayName: Copy files into binskim
+  inputs:
+    SourceFolder: '$(Build.SourcesDirectory)'
+    TargetFolder: '$(Pipeline.Workspace)\\binskim'
+    ${{ if ne(parameters.binskimPath, '') }}:
+      Contents: ${{ parameters.binskimPath }}
+    ${{ else }}:
+      Contents: |
+        **/*.dll
+        **/*.exe
 
-  - task: PostAnalysis@1
-    displayName: 'BinSkim: Post Analysis'
-    inputs:
-      BinSkim: true
-      BinSkimBreakOn: WarningAbove
+# Run BinSkim Tool by MicrosoftSecurityDevOps for Target of above Task  folder "binskim"
+- task: MicrosoftSecurityDevOps@1
+  displayName: 'Run BinSkim'
+  inputs:
+    tools: 'BinSkim'
+    break: true
+  env:
+    GDN_BINSKIM_TARGET: '$(Pipeline.Workspace)/binskim/**/*.*'
+    GDN_BINSKIM_RECURSE: 'true'
+    GDN_BINSKIM_VERBOSE: 'true'


### PR DESCRIPTION
Added task to run binskim tool with MicrosoftSecurityDevOps.
Similar implementation as in v2 ci-build pipeline.

Below are tasks newly added
1. Create folder "binskim".
2. Filter the Build.SourcesDirectory with contents only with wildcard pattern of "*.dll" and "*.exe", copy matching files to folder created in step 1.
3.  Initiate task MicrosoftSecurityDevOps to run tool binskim with target folder of Step 1 which had *.dll and *.exe files.
break is set true, in case of any error in binskim the pipeline will also fail.

Tested
Created a feature branch "feature/MicrosoftSecurityDevOps-binskim" in repo "sample-adh-assets_rest_api-dotnet"
with checkout of this AVEVA-Samples feature branch.
Initiated a Pipeline Run for "sample-adh-assets_rest_api-dotnet" and verified the results. The pipeline was successful.

![image](https://github.com/AVEVA/AVEVA-Samples/assets/154887338/b4343d94-9671-4ce8-b28d-535f1cecccaf)
![image](https://github.com/AVEVA/AVEVA-Samples/assets/154887338/2f46fcb1-f91c-4540-82ae-f6a8b849845a)
![image](https://github.com/AVEVA/AVEVA-Samples/assets/154887338/969c4878-6758-4101-9202-ae59d3f42699)