### PR TITLE
re-implemented param deletebinskim and task delete folder

### DIFF
--- a/miscellaneous/build_templates/binskim.yml
+++ b/miscellaneous/build_templates/binskim.yml
@@ -1,10 +1,22 @@
 # This template will perform a BinSkim with MicrosoftSecurityDevOps.
 parameters:
+- name: deleteBinSkim # This parameter is used to delete files before running BinSkim. Only use this if the error has been investigated and can be safely ignored
+  type: string
+  default: '' 
 - name: binskimPath
   type: string
   default: ""
 
 steps:
+# BinSkim errors if it encounters badly signed Microsoft files
+# To avoid this issue, delete the files before running BinSkim
+- task: DeleteFiles@1
+  displayName: 'BinSkim: Delete Files'
+  inputs:
+    SourceFolder: $(Build.SourcesDirectory)
+    Contents: '${{ parameters.deleteBinSkim }}'
+  condition: ne('${{ parameters.deleteBinSkim }}', '')
+
 # Create binskim folder
 - powershell: |
     New-Item -ItemType Directory -Force -Path "$(Build.SourcesDirectory)\binskim"


### PR DESCRIPTION
Few of the pipelines are using the param deletebinskim, to clear contents of folder path shared in param.
In previous commit, had removed this implementation. but is essential for couple of pipelines.

So, re-implemented those changes with deletebinskim param and delete contents of folder path shared in param.

Verification
Created a feature branch in repo sample-adh-csv_to_adh-dotnet and ref to checkout feature branch of AVEVA-Samples.
Task completed successfully with Run BinSkim Task as well.
But, overall pipeline is failing due to BlackDuck Notices

![image](https://github.com/AVEVA/AVEVA-Samples/assets/154887338/17c1ae18-cd05-4101-adfb-af2beea7f5c0)

![image](https://github.com/AVEVA/AVEVA-Samples/assets/154887338/e8396496-5eef-4e2b-8f00-916eb7c0aa3b)