### PR TITLE
updated binskim.yml, set break false.

### DIFF
--- a/miscellaneous/build_templates/binskim.yml
+++ b/miscellaneous/build_templates/binskim.yml
@@ -40,7 +40,7 @@ steps:
   displayName: 'Run BinSkim'
   inputs:
     tools: 'BinSkim'
-    break: true
+    break: false
   env:
     GDN_BINSKIM_TARGET: '$(Pipeline.Workspace)/binskim/**/*.*'
     GDN_BINSKIM_RECURSE: 'true'


### PR DESCRIPTION
updated the binskim.yml, set property "break" with value "false".

Binskim has been reported with issues, and there are no. of errors encountered in our implementation pipelines as well. which were working fine couple of weeks back.

Similar implementation in connect v2 as well and at the moment they've disabled the binskim check.
For ADH Samples project, we will be running the binskim task but define "break" false. So, even will binskim errors the pipeline is succeeded and not failed.

Once those binskim issues are resolved or alternate is implemented in connect v2, we can implement same or set "break" true.

Verification,
Created a feature branch "feature/binskim-test" for [sample-eds-eds_analytics-dotnet], with ref to this AVEVA-Samples feature branch (feature-binskim), initiated pipeline run and is succeeded.

Binskim Issues reported in connect v2
https://teams.microsoft.com/l/message/19:a0324518599f42c095631513fdc6ede7@thread.tacv2/1711142796165?tenantId=425a5546-5a6e-4f1b-ab62-23d91d07d893&groupId=cd9cd57e-cc56-4149-874c-1aca070ba4f8&parentMessageId=1710526619348&teamName=Cloud%20Platform&channelName=Support%20-%20Operations&createdTime=1711142796165

Pipeline:
https://dev.azure.com/AVEVA-VSTS/Cloud%20Platform/_build/results?buildId=3694609&view=results
