### PR TITLE
Agent Pool Migration for all samples code-analysis.yml

### DIFF
--- a/miscellaneous/build_templates/code-analysis.yml
+++ b/miscellaneous/build_templates/code-analysis.yml
@@ -37,7 +37,11 @@ jobs:
   - powershell: |
       echo "##vso[task.setvariable variable=POLARIS_PROJECT_NAME]$(analysisProject)"
     displayName: Set POLARIS_PROJECT_NAME
-    
+  - task: JavaToolInstaller@0
+    inputs:
+      versionSpec: '11'  # or '17', '8', etc.
+      jdkArchitecture: 'x64'
+      jdkSourceOption: 'PreInstalled'  # Options: PreInstalled, AzureStorage, LocalDirectory
   - task: blackduck.blackduck-coverity-on-polaris.blackduck-coverity-on-polaris-task.BlackduckCoverityOnPolaris@2
     displayName: Polaris Analyze
     inputs:

--- a/miscellaneous/build_templates/code-analysis.yml
+++ b/miscellaneous/build_templates/code-analysis.yml
@@ -34,7 +34,7 @@ jobs:
   steps:
   - ${{ parameters.buildSteps }}
   
-  - bash: |
+  - powershell: |
       echo "##vso[task.setvariable variable=POLARIS_PROJECT_NAME]$(analysisProject)"
     displayName: Set POLARIS_PROJECT_NAME
     

--- a/miscellaneous/build_templates/code-analysis.yml
+++ b/miscellaneous/build_templates/code-analysis.yml
@@ -52,7 +52,7 @@ jobs:
     buildSteps:
       - task: JavaToolInstaller@0
         inputs:
-          versionSpec: '11'  # or '17', '8', etc.
+          versionSpec: '8'  # or '17', '8', etc.
           jdkArchitectureOption: 'x64'
           jdkSourceOption: 'PreInstalled'  # Options: PreInstalled, AzureStorage, LocalDirectory
       - ${{ parameters.buildSteps }}

--- a/miscellaneous/build_templates/code-analysis.yml
+++ b/miscellaneous/build_templates/code-analysis.yml
@@ -30,8 +30,7 @@ jobs:
 - job: SynopsysPolarisScan
   timeoutInMinutes: 180
   pool:
-      name: DevOps Managed Containers Build
-      demands: AgentType -equals osimanagedagent
+      name: DevOps Managed AKS Admin
   steps:
   - ${{ parameters.buildSteps }}
   
@@ -50,8 +49,7 @@ jobs:
 - template: Pipelines/Templates/BlackDuck/BlackDuckSourceScan.step.v1.yml@OpsGuildAutomationRepo
   parameters:
     pool:
-      name: DevOps Managed Containers Build
-      demands: AgentType -equals osimanagedagent
+      name: DevOps Managed AKS Admin
     buildSteps:
       - ${{ parameters.buildSteps }}
       - script: pip install -r requirements.txt

--- a/miscellaneous/build_templates/code-analysis.yml
+++ b/miscellaneous/build_templates/code-analysis.yml
@@ -44,18 +44,11 @@ jobs:
       polarisService: 'PolarisScanner'
       waitForIssues: true
     condition: and(succeeded(), eq(${{ parameters.skip }}, false), eq(${{ parameters.skipPolaris }}, false))
-    
-- template: Pipelines/Templates/BlackDuck/BlackDuckSourceScan.step.v3.yml@OpsGuildAutomationRepo
-  parameters:
-    pool:
-      name: DevOps Managed AKS Admin
-    buildSteps:
-      - ${{ parameters.buildSteps }}
-      - script: pip install -r requirements.txt
-        condition: and(succeeded(), eq(${{ parameters.skip }}, false), eq(${{ parameters.useRequirementsTxt }}, true))
-        displayName: 'Install requirements.txt'
-    projectName: "product-readiness.$(analysisProject)"
-    projectVersionName: "$(Build.SourceBranchName)"
-    sourcePath: "$(Build.SourcesDirectory)${{ parameters.projectPath }}"
-    blackDuckServiceConnection: 'BlackDuckScanner'
-    detectorSearchDepth: 0
+
+  - template: "Pipelines/Templates/BlackDuck/v3/BlackDuckScanTemplate.step.v3.yml@ArchitectureRepo"
+    parameters:
+      projectName: product-readiness.$(analysisProject)
+      projectVersionName: "$(Build.SourceBranchName)"
+      blackDuckServiceConnection: 'BlackDuckScanner'
+  
+

--- a/miscellaneous/build_templates/code-analysis.yml
+++ b/miscellaneous/build_templates/code-analysis.yml
@@ -53,7 +53,7 @@ jobs:
       - task: JavaToolInstaller@0
         inputs:
           versionSpec: '11'  # or '17', '8', etc.
-          jdkArchitecture: 'x64'
+          jdkArchitectureOption: 'x64'
           jdkSourceOption: 'PreInstalled'  # Options: PreInstalled, AzureStorage, LocalDirectory
       - ${{ parameters.buildSteps }}
       - script: pip install -r requirements.txt

--- a/miscellaneous/build_templates/code-analysis.yml
+++ b/miscellaneous/build_templates/code-analysis.yml
@@ -30,8 +30,7 @@ jobs:
 - job: SynopsysPolarisScan
   timeoutInMinutes: 180
   pool:
-      # name: DevOps Managed AKS Admin
-      vmImage: windows-2022
+      name: Cloud Platform CONNECT v2 Development
   steps:
   - ${{ parameters.buildSteps }}
   

--- a/miscellaneous/build_templates/code-analysis.yml
+++ b/miscellaneous/build_templates/code-analysis.yml
@@ -23,14 +23,18 @@ parameters:
   - name: buildSteps
     type: stepList
     default: []
-
+    
+  # Agent pool on which to run the BlackDuck scans
+  - name: poolForExecution
+    type: string
+    default: 'Cloud Platform CONNECT v2 Development'
 
 jobs:   
 
 - job: BlackDuckScans
   timeoutInMinutes: 180
   pool:
-      name: Cloud Platform CONNECT v2 Development
+      name: ${{ parameters.poolForExecution }}
   steps:
   - ${{ parameters.buildSteps }}
   

--- a/miscellaneous/build_templates/code-analysis.yml
+++ b/miscellaneous/build_templates/code-analysis.yml
@@ -27,7 +27,7 @@ parameters:
 
 jobs:   
 
-- job: SynopsysPolarisScan
+- job: BlackDuckScans
   timeoutInMinutes: 180
   pool:
       name: Cloud Platform CONNECT v2 Development

--- a/miscellaneous/build_templates/code-analysis.yml
+++ b/miscellaneous/build_templates/code-analysis.yml
@@ -44,7 +44,14 @@ jobs:
       polarisService: 'PolarisScanner'
       waitForIssues: true
     condition: and(succeeded(), eq(${{ parameters.skip }}, false), eq(${{ parameters.skipPolaris }}, false))
-
+    
+  - powershell: |
+      where java
+      $env:JAVA_HOME = "$env:JAVA_HOME_17_X64"
+      $env:PATH = "$env:JAVA_HOME\bin;$env:PATH"
+      java -version
+    displayName: "Use Java 17"
+  
   - template: "Pipelines/Templates/BlackDuck/v3/BlackDuckScanTemplate.step.v3.yml@ArchitectureRepo"
     parameters:
       projectName: product-readiness.$(analysisProject)

--- a/miscellaneous/build_templates/code-analysis.yml
+++ b/miscellaneous/build_templates/code-analysis.yml
@@ -30,7 +30,8 @@ jobs:
 - job: SynopsysPolarisScan
   timeoutInMinutes: 180
   pool:
-      name: DevOps Managed AKS Admin
+      # name: DevOps Managed AKS Admin
+      vmImage: windows-2022
   steps:
   - ${{ parameters.buildSteps }}
   

--- a/miscellaneous/build_templates/code-analysis.yml
+++ b/miscellaneous/build_templates/code-analysis.yml
@@ -45,16 +45,11 @@ jobs:
       waitForIssues: true
     condition: and(succeeded(), eq(${{ parameters.skip }}, false), eq(${{ parameters.skipPolaris }}, false))
     
-- template: Pipelines/Templates/BlackDuck/BlackDuckSourceScan.step.v1.yml@OpsGuildAutomationRepo
+- template: Pipelines/Templates/BlackDuck/BlackDuckSourceScan.step.v3.yml@OpsGuildAutomationRepo
   parameters:
     pool:
       name: DevOps Managed AKS Admin
     buildSteps:
-      - task: JavaToolInstaller@0
-        inputs:
-          versionSpec: '8'  # or '17', '8', etc.
-          jdkArchitectureOption: 'x64'
-          jdkSourceOption: 'PreInstalled'  # Options: PreInstalled, AzureStorage, LocalDirectory
       - ${{ parameters.buildSteps }}
       - script: pip install -r requirements.txt
         condition: and(succeeded(), eq(${{ parameters.skip }}, false), eq(${{ parameters.useRequirementsTxt }}, true))

--- a/miscellaneous/build_templates/code-analysis.yml
+++ b/miscellaneous/build_templates/code-analysis.yml
@@ -37,11 +37,6 @@ jobs:
   - powershell: |
       echo "##vso[task.setvariable variable=POLARIS_PROJECT_NAME]$(analysisProject)"
     displayName: Set POLARIS_PROJECT_NAME
-  - task: JavaToolInstaller@0
-    inputs:
-      versionSpec: '11'  # or '17', '8', etc.
-      jdkArchitecture: 'x64'
-      jdkSourceOption: 'PreInstalled'  # Options: PreInstalled, AzureStorage, LocalDirectory
   - task: blackduck.blackduck-coverity-on-polaris.blackduck-coverity-on-polaris-task.BlackduckCoverityOnPolaris@2
     displayName: Polaris Analyze
     inputs:
@@ -55,6 +50,11 @@ jobs:
     pool:
       name: DevOps Managed AKS Admin
     buildSteps:
+      - task: JavaToolInstaller@0
+        inputs:
+          versionSpec: '11'  # or '17', '8', etc.
+          jdkArchitecture: 'x64'
+          jdkSourceOption: 'PreInstalled'  # Options: PreInstalled, AzureStorage, LocalDirectory
       - ${{ parameters.buildSteps }}
       - script: pip install -r requirements.txt
         condition: and(succeeded(), eq(${{ parameters.skip }}, false), eq(${{ parameters.useRequirementsTxt }}, true))

--- a/miscellaneous/build_templates/code-analysis.yml
+++ b/miscellaneous/build_templates/code-analysis.yml
@@ -44,13 +44,6 @@ jobs:
       polarisService: 'PolarisScanner'
       waitForIssues: true
     condition: and(succeeded(), eq(${{ parameters.skip }}, false), eq(${{ parameters.skipPolaris }}, false))
-    
-  - powershell: |
-      where java
-      $env:JAVA_HOME = "$env:JAVA_HOME_17_X64"
-      $env:PATH = "$env:JAVA_HOME\bin;$env:PATH"
-      java -version
-    displayName: "Use Java 17"
   
   - template: "Pipelines/Templates/BlackDuck/v3/BlackDuckScanTemplate.step.v3.yml@ArchitectureRepo"
     parameters:


### PR DESCRIPTION
Pipeline agent pool for "osimanagedagent" has been decommissioned. This PR is the result of collaborating with Ops CICD to find a new proper agent pool configuration that will work in general for pipelines for AVEVA samples.

Summary:

- Agent Pool Name is parameterized, defaulted to "Cloud Platform CONNECT v2 Development"
- BlackDuck job template updated to v3 from Architecture repo
- PowerShell used for "Set POLARIS_PROJECT_NAME" task for compatibility

Testing:

- Sample "sample-adh-authentication_client_credentials_simple-nodejs" has been used for testing, [branch "agentpoolmigration"](https://github.com/AVEVA/sample-adh-authentication_client_credentials_simple-nodejs/tree/agentpoolmigration)
- Pipelines are all green including building, testing, Polaris and BlackDuck scans
